### PR TITLE
Log directories to watch on startup

### DIFF
--- a/configmap-reload.go
+++ b/configmap-reload.go
@@ -72,6 +72,7 @@ func main() {
 	}()
 
 	for _, d := range volumeDirs {
+		log.Printf("Watching directory: %q", d)
 		err = watcher.Add(d)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
This should add feedback that could avoid operating error like #6