### PR TITLE
modified to use base image gcr.io/distroless/base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM gcr.io/distroless/base
 
 COPY out/configmap-reload /configmap-reload
 


### PR DESCRIPTION
This modification is to allow reloading of Prometheus 2.0 in certain circumstances.  I'll explain my own.

I'm running Prometheus in an Openshift cluster and I have the web.exernal-url set to the name of the ingress route (which has insecureEdgeTerminationPolicy=Redirect set, so all traffic redirects to https).

As far as I can tell, when you have web.external-url set, posting to localhost:9090 redirects to the external-url (which is https in my case).