### PR TITLE
Fix dep/fsnotify build error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,12 +10,12 @@
   name = "gopkg.in/fsnotify.v1"
   packages = ["."]
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
-  source = "git@github.com:fsnotify/fsnotify"
+  source = "https://github.com/fsnotify/fsnotify.git"
   version = "v1.4.7"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9b542428be07a91317030bab42399c68a6ab5c73a4667fb52a3917b23ca1cb2c"
+  inputs-digest = "779fa34727af844f762abc361a4371e3c6a11f9e998ceb2012615eddfa3d8366"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,11 +10,12 @@
   name = "gopkg.in/fsnotify.v1"
   packages = ["."]
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  source = "git@github.com:fsnotify/fsnotify"
   version = "v1.4.7"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f5d2b1926d2addabb2fbb97e5237ff5344adfd415f363c02db894983f5d88baf"
+  inputs-digest = "9b542428be07a91317030bab42399c68a6ab5c73a4667fb52a3917b23ca1cb2c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,3 +5,10 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+# Fixes https://github.com/golang/dep/issues/1760
+
+[[override]]
+  name = "gopkg.in/fsnotify.v1"
+  version = "1.2.9"
+  source = "git@github.com:fsnotify/fsnotify"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,4 +11,4 @@
 [[override]]
   name = "gopkg.in/fsnotify.v1"
   version = "1.2.9"
-  source = "git@github.com:fsnotify/fsnotify"
+  source = "https://github.com/fsnotify/fsnotify.git"


### PR DESCRIPTION
I'm getting the following error on build:
```
$ make
...
Gopkg.lock was already in sync with imports and Gopkg.toml
(1/2) Failed to write gopkg.in/fsnotify.v1@v1.4.7
(2/2) Failed to write golang.org/x/sys@9c60d1c508f5134d1ca726b4641db998f2523357
grouped write of manifest, lock and vendor: error while writing out vendor tree: failed to write dep tree: failed to export gopkg.in/fsnotify.v1: fatal: failed to unpack tree object c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
: exit status 128
make: *** [.vendor] Error 1
```

Looks like https://github.com/golang/dep/issues/1760, adding an override for fsnotify fixes it 👌 