### PR TITLE
Fix `failed to unpack tree object`; remove gopkg

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,19 +2,20 @@
 
 
 [[projects]]
-  name = "golang.org/x/sys"
-  packages = ["unix"]
-  revision = "9c60d1c508f5134d1ca726b4641db998f2523357"
-
-[[projects]]
-  name = "gopkg.in/fsnotify.v1"
+  name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  revision = "9c60d1c508f5134d1ca726b4641db998f2523357"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f5d2b1926d2addabb2fbb97e5237ff5344adfd415f363c02db894983f5d88baf"
+  inputs-digest = "6d23f84d9fa789aba9d27c257a11bb39fd4be7c8846a5752dfc2b631b207971f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,5 +1,5 @@
 [[constraint]]
-  name = "gopkg.in/fsnotify.v1"
+  name = "github.com/fsnotify/fsnotify"
   version = "1.4.7"
 
 [prune]

--- a/configmap-reload.go
+++ b/configmap-reload.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	fsnotify "gopkg.in/fsnotify.v1"
+	fsnotify "github.com/fsnotify/fsnotify"
 )
 
 var volumeDirs volumeDirsFlag


### PR DESCRIPTION
Removes gopkg.in from import paths and re-initializes Gopkg.{toml,lock}.
This fixes an apparent problem with git.

While building I ran over this git error:

> ✔ /go/configmap-reload/src/github.com/jimmidyson/configmap-reload [master|✔]
> $ git describe
> v0.2.2-1-g633f4c9
> ✔ /go/configmap-reload/src/github.com/jimmidyson/configmap-reload [master|✔]
> $ git clean -x -f -d
> ✔ /go/configmap-reload/src/github.com/jimmidyson/configmap-reload [master|✔]
> $ dep ensure --vendor-only
> grouped write of manifest, lock and vendor: error while writing out vendor tree: failed to write dep tree: failed to export gopkg.in/fsnotify.v1: fatal: failed to unpack tree object c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
> : exit status 128
> $ dep version
> dep:
>  version     : devel
>  build date  :
>  git hash    :
>  go version  : devel +1a27f048ad Fri Jun 29 15:20:52 2018 +0000
>  go compiler : gc
>  platform    : linux/amd64
>  features    : ImportDuringSolve=false

Anyway, removing gopkg.in from import paths and doing a `dep init` from
scratch fixed it for me, so I did not bother to get to the bottom of
this.

IMHO gopkg.in is obsolete when versioning is managed by a tool like dep.