### PR TITLE
Fix fsnotify dependency by adding source in Gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,7 @@
 [[constraint]]
   name = "gopkg.in/fsnotify.v1"
   version = "1.4.7"
+  source = "https://github.com/fsnotify/fsnotify.git"
 
 [prune]
   go-tests = true


### PR DESCRIPTION
Right now, `dep ensure` fails with
```
Solving failure: No versions of gopkg.in/fsnotify.v1 met constraints:
	v1.4.7: unable to update checked out version: fatal: reference is not a tree: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
: command failed: [git checkout c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9]: exit status 128
```

This is a known issue with `dep` and `gopkg.in` packages that incorrectly point to the source repository.

This PR fixes the `gopkg.in/fsnotify.v1` dependency by pinning the source in `Gopkg.toml` as suggested in golang/dep#1799 (comment).