### PR TITLE
[WIP] *: multiarch container build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,11 +74,7 @@ jobs:
           name: Build Docker image
           command: |
             apk add -U make bash
-            make docker GOOS=linux GOARCH=amd64 DOCKER_IMAGE_TAG=${CIRCLE_SHA1}
-            make docker GOOS=linux GOARCH=arm DOCKER_IMAGE_TAG=${CIRCLE_SHA1}
-            make docker GOOS=linux GOARCH=arm64 DOCKER_IMAGE_TAG=${CIRCLE_SHA1}
-            make docker GOOS=linux GOARCH=ppc64le DOCKER_IMAGE_TAG=${CIRCLE_SHA1}
-            make docker GOOS=linux GOARCH=s390x DOCKER_IMAGE_TAG=${CIRCLE_SHA1}
+            for i in amd64 arm arm64 ppc64le s390x; do make docker GOOS=linux GOARCH=$i DOCKER_IMAGE_TAG=${CIRCLE_SHA1}; done
 
   push_docker:
     <<: *job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,20 +75,10 @@ jobs:
           command: |
             apk add -U make bash
             make docker GOOS=linux GOARCH=amd64 DOCKER_IMAGE_TAG=${CIRCLE_SHA1}
-
-      - run:
-          name: Export Docker image
-          command: |
-            docker save -o ./configmap-reload-docker.tar jimmidyson/configmap-reload:${CIRCLE_SHA1}
-
-      - persist_to_workspace:
-          root: .
-          paths:
-          - configmap-reload-docker.tar
-
-      - store_artifacts:
-          path: ./configmap-reload-docker.tar
-          destination: configmap-reload-docker.tar
+            make docker GOOS=linux GOARCH=arm DOCKER_IMAGE_TAG=${CIRCLE_SHA1}
+            make docker GOOS=linux GOARCH=arm64 DOCKER_IMAGE_TAG=${CIRCLE_SHA1}
+            make docker GOOS=linux GOARCH=ppc64le DOCKER_IMAGE_TAG=${CIRCLE_SHA1}
+            make docker GOOS=linux GOARCH=s390x DOCKER_IMAGE_TAG=${CIRCLE_SHA1}
 
   push_docker:
     <<: *job_defaults
@@ -99,9 +89,6 @@ jobs:
     steps:
       - setup_remote_docker:
           version: 18.09.3
-
-      - attach_workspace:
-          at: .
 
       - run:
           name: Push Docker image
@@ -114,11 +101,9 @@ jobs:
               echo "Missing Docker login information!!!"
               exit 1
             fi
-            docker load -q -i ./configmap-reload-docker.tar
-            DOCKER_TAG=${CIRCLE_TAG:-latest}
-            docker tag jimmidyson/configmap-reload:${CIRCLE_SHA1} jimmidyson/configmap-reload:${DOCKER_TAG}
+            DOCKER_IMAGE_TAG=${CIRCLE_TAG:-latest}
             docker login -u ${DOCKER_LOGIN} -p ${DOCKER_PASSWORD}
-            docker push jimmidyson/configmap-reload:${DOCKER_TAG}
+            make push
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out/
 _gopath/
 vendor/
 .vendor
+manifest-tool

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM gcr.io/distroless/base
-USER	65534
+ARG BASEIMAGE=busybox
+FROM $BASEIMAGE
 
-COPY out/configmap-reload /configmap-reload
+USER 65534
+
+ARG BINARY=configmap-reload
+COPY out/$BINARY /configmap-reload
 
 ENTRYPOINT ["/configmap-reload"]

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,33 @@ LDFLAGS := -s -w -extldflags '-static'
 
 SRCFILES := $(shell find . ! -path './out/*' ! -path './.git/*' -type f)
 
+ALL_ARCH=amd64 arm arm64 ppc64le s390x
+ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x
 ALL_BINARIES ?= $(addprefix out/configmap-reload-, \
-									$(addprefix linux-,amd64 ppc64le s390x arm64) \
+									$(addprefix linux-,amd64 ppc64le s390x arm arm64) \
 									darwin-amd64 \
 									windows-amd64.exe)
+
+ifeq ($(GOARCH),amd64)
+	BASEIMAGE?=busybox
+	BINARY=configmap-reload-linux-amd64
+endif
+ifeq ($(GOARCH),arm)
+	BASEIMAGE?=armhf/busybox
+	BINARY=configmap-reload-linux-arm
+endif
+ifeq ($(GOARCH),arm64)
+	BASEIMAGE?=aarch64/busybox
+	BINARY=configmap-reload-linux-arm64
+endif
+ifeq ($(GOARCH),ppc64le)
+	BASEIMAGE?=ppc64le/busybox
+	BINARY=configmap-reload-linux-ppc64le
+endif
+ifeq ($(GOARCH),s390x)
+	BASEIMAGE?=s390x/busybox
+	BINARY=configmap-reload-linux-s390x
+endif
 
 out/configmap-reload: out/configmap-reload-$(GOOS)-$(GOARCH)
 	cp out/configmap-reload-$(GOOS)-$(GOARCH) out/configmap-reload
@@ -58,5 +81,16 @@ clean:
 	rm -rf out
 
 .PHONY: docker
-docker: out/configmap-reload Dockerfile
-	docker build -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) .
+docker: out/configmap-reload-$(GOOS)-$(GOARCH) Dockerfile
+	docker build --build-arg BASEIMAGE=$(BASEIMAGE) --build-arg BINARY=$(BINARY) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)-$(GOARCH) .
+
+./manifest-tool:
+	curl -sSL https://github.com/estesp/manifest-tool/releases/download/v0.5.0/manifest-tool-linux-amd64 > manifest-tool
+	chmod +x manifest-tool
+
+push-%:
+	$(MAKE) GOARCH=$* docker
+	docker push $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)-$*
+
+push: ./manifest-tool $(addprefix push-,$(ALL_ARCH))
+	./manifest-tool push from-args --platforms $(ML_PLATFORMS) --template $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)-ARCH --target $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)


### PR DESCRIPTION
Adding support for building multiarch container images

- Changed base image to busybox as gcr.io/distroless/base doesn't support multiple architectures
- Not building docker images for windows and darwin, but this could be easily extended if appropriate base image is found
- Adding support for ARM platform

All this was tested with:
```bash
make DOCKER_IMAGE_NAME=paulfantom/configmap-reload push
```
and result can be seen at https://hub.docker.com/r/paulfantom/configmap-reload/tags and also by verifying it with:
```bash
docker manifest inspect paulfantom/configmap-reload
```

DO NOT MERGE as CI system needs to be adjusted first.