### PR TITLE
Fix broken curl in multiarch build + fix retry logic break

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ jobs:
           name: Push multiarch Docker image
           command: |
             apk add -U make bash curl
+            apk upgrade
             make manifest-push DOCKER_IMAGE_TAG=${CIRCLE_TAG:-latest}
 
 workflows:

--- a/configmap-reload.go
+++ b/configmap-reload.go
@@ -116,7 +116,7 @@ func main() {
 						}
 					}
 					for retries := *webhookRetries; retries != 0; retries-- {
-						log.Printf("performing webhook request (%d/%d)", retries, *webhookRetries+1)
+						log.Printf("performing webhook request (%d/%d)", retries, *webhookRetries)
 						resp, err := http.DefaultClient.Do(req)
 						if err != nil {
 							setFailureMetrics(h.String(), "client_request_do")

--- a/configmap-reload.go
+++ b/configmap-reload.go
@@ -134,7 +134,7 @@ func main() {
 						}
 						setSuccessMetrict(h.String(), begun)
 						log.Println("successfully triggered reload")
-						return
+						break
 					}
 				}
 			case err := <-watcher.Errors:


### PR DESCRIPTION
In this PR:

- Fix multi arch build (curl problem)
- Fix retry logic that would break further reloads
- Expose metric for exhausted retries

After searching a bit regarding this error, apparently `apk` does not bring the newest versions of some libs; you need to forcibly upgrade them. That fixes the `curl` problem during the multi arch build.

Before:
```
$ docker run -it --rm --entrypoint sh docker:19.03.1-git
/ # apk add -U make bash curl
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
(1/4) Installing readline (8.0.0-r0)
(2/4) Installing bash (5.0.0-r0)
Executing bash-5.0.0-r0.post-install
(3/4) Installing curl (7.66.0-r0)
(4/4) Installing make (4.2.1-r2)
Executing busybox-1.30.1-r2.trigger
OK: 33 MiB in 30 packages
/ # curl https://google.com
Error relocating /usr/bin/curl: curl_multi_poll: symbol not found
```

After:

```
$ docker run -it --rm --entrypoint sh docker:19.03.1-git
/ # apk add -U make bash curl
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
(1/4) Installing readline (8.0.0-r0)
(2/4) Installing bash (5.0.0-r0)
Executing bash-5.0.0-r0.post-install
(3/4) Installing curl (7.66.0-r0)
(4/4) Installing make (4.2.1-r2)
Executing busybox-1.30.1-r2.trigger
OK: 33 MiB in 30 packages
/ # apk upgrade # <--------------------------- this does the fix to the curl command
(1/15) Upgrading busybox (1.30.1-r2 -> 1.30.1-r4)
Executing busybox-1.30.1-r4.post-upgrade
(2/15) Upgrading libcrypto1.1 (1.1.1c-r0 -> 1.1.1g-r0)
(3/15) Upgrading libssl1.1 (1.1.1c-r0 -> 1.1.1g-r0)
(4/15) Upgrading ca-certificates-cacert (20190108-r0 -> 20191127-r2)
(5/15) Upgrading ssl_client (1.30.1-r2 -> 1.30.1-r4)
(6/15) Upgrading ncurses-terminfo-base (6.1_p20190518-r0 -> 6.1_p20190518-r2)
(7/15) Upgrading ncurses-libs (6.1_p20190518-r0 -> 6.1_p20190518-r2)
(8/15) Purging ncurses-terminfo (6.1_p20190518-r0)
(9/15) Upgrading ca-certificates (20190108-r0 -> 20191127-r2)
(10/15) Upgrading nghttp2-libs (1.38.0-r0 -> 1.39.2-r1)
(11/15) Upgrading libcurl (7.65.1-r0 -> 7.66.0-r0)
(12/15) Upgrading expat (2.2.7-r0 -> 2.2.8-r0)
(13/15) Upgrading git (2.22.0-r0 -> 2.22.4-r0)
(14/15) Upgrading openssh-keygen (8.0_p1-r0 -> 8.1_p1-r0)
(15/15) Upgrading openssh-client (8.0_p1-r0 -> 8.1_p1-r0)
Executing busybox-1.30.1-r4.trigger
Executing ca-certificates-20191127-r2.trigger
OK: 27 MiB in 29 packages
/ # curl https://google.com
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="https://www.google.com/">here</A>.
</BODY></HTML>
```