### PR TITLE
chore: spelling: metrics

### DIFF
--- a/configmap-reload.go
+++ b/configmap-reload.go
@@ -136,7 +136,7 @@ func main() {
 							continue
 						}
 
-						setSuccessMetrict(h.String(), begun)
+						setSuccessMetrics(h.String(), begun)
 						log.Println("successfully triggered reload")
 						successfulReloadWebhook = true
 						break
@@ -170,7 +170,7 @@ func setFailureMetrics(h, reason string) {
 	lastReloadError.WithLabelValues(h).Set(1.0)
 }
 
-func setSuccessMetrict(h string, begun time.Time) {
+func setSuccessMetrics(h string, begun time.Time) {
 	requestDuration.WithLabelValues(h).Set(time.Since(begun).Seconds())
 	successReloads.WithLabelValues(h).Inc()
 	lastReloadError.WithLabelValues(h).Set(0.0)


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/jimmidyson-configmap-reload/commit/3ccf190a157f7affcc439b571be6c4147f8b6b83#commitcomment-42644561

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/jimmidyson-configmap-reload/commit/c290e4b3b4d9e2bfaa9298a49c03025093d2f416

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.
