### PR TITLE
chore: bump busybox version to latest stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ ALL_BINARIES ?= $(addprefix out/configmap-reload-, \
 									darwin-amd64 \
 									windows-amd64.exe)
 
-DEFAULT_BASEIMAGE_amd64   := amd64/busybox:1.33.0
-DEFAULT_BASEIMAGE_arm     := arm32v7/busybox:1.33.0
-DEFAULT_BASEIMAGE_arm64   := arm64v8/busybox:1.33.0
-DEFAULT_BASEIMAGE_ppc64le := ppc64le/busybox:1.33.0
-DEFAULT_BASEIMAGE_s390x   := s390x/busybox:1.33.0
+DEFAULT_BASEIMAGE_amd64   := amd64/busybox:1.34.0
+DEFAULT_BASEIMAGE_arm     := arm32v7/busybox:1.34.0
+DEFAULT_BASEIMAGE_arm64   := arm64v8/busybox:1.34.0
+DEFAULT_BASEIMAGE_ppc64le := ppc64le/busybox:1.34.0
+DEFAULT_BASEIMAGE_s390x   := s390x/busybox:1.34.0
 
 BASEIMAGE ?= $(DEFAULT_BASEIMAGE_$(GOARCH))
 

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ ALL_BINARIES ?= $(addprefix out/configmap-reload-, \
 									darwin-amd64 \
 									windows-amd64.exe)
 
-DEFAULT_BASEIMAGE_amd64   := amd64/busybox:1.34.0
-DEFAULT_BASEIMAGE_arm     := arm32v7/busybox:1.34.0
-DEFAULT_BASEIMAGE_arm64   := arm64v8/busybox:1.34.0
-DEFAULT_BASEIMAGE_ppc64le := ppc64le/busybox:1.34.0
-DEFAULT_BASEIMAGE_s390x   := s390x/busybox:1.34.0
+DEFAULT_BASEIMAGE_amd64   := amd64/busybox:1.34
+DEFAULT_BASEIMAGE_arm     := arm32v7/busybox:1.34
+DEFAULT_BASEIMAGE_arm64   := arm64v8/busybox:1.34
+DEFAULT_BASEIMAGE_ppc64le := ppc64le/busybox:1.34
+DEFAULT_BASEIMAGE_s390x   := s390x/busybox:1.34
 
 BASEIMAGE ?= $(DEFAULT_BASEIMAGE_$(GOARCH))
 

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ ALL_BINARIES ?= $(addprefix out/configmap-reload-, \
 									darwin-amd64 \
 									windows-amd64.exe)
 
-DEFAULT_BASEIMAGE_amd64   := amd64/busybox:1.34
-DEFAULT_BASEIMAGE_arm     := arm32v7/busybox:1.34
-DEFAULT_BASEIMAGE_arm64   := arm64v8/busybox:1.34
-DEFAULT_BASEIMAGE_ppc64le := ppc64le/busybox:1.34
-DEFAULT_BASEIMAGE_s390x   := s390x/busybox:1.34
+DEFAULT_BASEIMAGE_amd64   := amd64/busybox:stable
+DEFAULT_BASEIMAGE_arm     := arm32v7/busybox:stable
+DEFAULT_BASEIMAGE_arm64   := arm64v8/busybox:stable
+DEFAULT_BASEIMAGE_ppc64le := ppc64le/busybox:stable
+DEFAULT_BASEIMAGE_s390x   := s390x/busybox:stable
 
 BASEIMAGE ?= $(DEFAULT_BASEIMAGE_$(GOARCH))
 


### PR DESCRIPTION
Not sure if you would prefer to pin the version here or pin to something like the `stable` docker tag. Let me know and I can change that if you would prefer that.

Fixes #68.