### PR TITLE
Build with go 1.19, upgrade dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ job_defaults: &job_defaults
   working_directory: /go/src/github.com/jimmidyson/configmap-reload
 
   docker:
-  - image: golang:1.17
+  - image: golang:1.19
 
   environment: &env_defaults
   - CGO_ENABLED: "0"

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/jimmidyson/configmap-reload
 
-go 1.17
+go 1.18
 
 require (
-	github.com/fsnotify/fsnotify v1.5.1
+	github.com/fsnotify/fsnotify v1.5.4
 	github.com/prometheus/client_golang v1.12.2
 )
 
@@ -15,6 +15,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jimmidyson/configmap-reload
 
-go 1.18
+go 1.19
 
 require (
 	github.com/fsnotify/fsnotify v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
-github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
+github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -309,9 +309,9 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Build with minimum Go version 1.18
Upgrade fsnotify to v1.5.4


**Build tests:**

Build all configmap-reload binaries 
```
$ make clean cross out/configmap-reload
rm -rf out
GOARCH=amd64 GOOS=linux \
go build --installsuffix cgo -ldflags="-s -w -extldflags '-static'" -a \
-o out/configmap-reload-linux-amd64 configmap-reload.go
GOARCH=arm GOOS=linux \
go build --installsuffix cgo -ldflags="-s -w -extldflags '-static'" -a \
-o out/configmap-reload-linux-arm configmap-reload.go
GOARCH=arm64 GOOS=linux \
go build --installsuffix cgo -ldflags="-s -w -extldflags '-static'" -a \
-o out/configmap-reload-linux-arm64 configmap-reload.go
GOARCH=ppc64le GOOS=linux \
go build --installsuffix cgo -ldflags="-s -w -extldflags '-static'" -a \
-o out/configmap-reload-linux-ppc64le configmap-reload.go
GOARCH=s390x GOOS=linux \
go build --installsuffix cgo -ldflags="-s -w -extldflags '-static'" -a \
-o out/configmap-reload-linux-s390x configmap-reload.go
GOARCH=amd64 GOOS=darwin \
go build --installsuffix cgo -ldflags="-s -w -extldflags '-static'" -a \
-o out/configmap-reload-darwin-amd64 configmap-reload.go
GOARCH=amd64 GOOS=windows \
go build --installsuffix cgo -ldflags="-s -w -extldflags '-static'" -a \
-o out/configmap-reload-windows-amd64.exe configmap-reload.go
cp out/configmap-reload-linux-amd64 out/configmap-reload
```

Check binary
```
$ ./out/configmap-reload
2022/10/06 22:27:12 Missing volume-dir
2022/10/06 22:27:12
Usage of ./out/configmap-reload:
-volume-dir value
the config map volume directory to watch for updates; may be used multiple times
-web.listen-address string
Address to listen on for web interface and telemetry. (default ":9533")
-web.telemetry-path string
Path under which to expose metrics. (default "/metrics")
-webhook-method string
the HTTP method url to use to send the webhook (default "POST")
-webhook-retries int
the amount of times to retry the webhook reload request (default 1)
-webhook-status-code int
the HTTP status code indicating successful triggering of reload (default 200)
-webhook-url value
the url to send a request to when the specified config map volume directory has been updated
```

Publish docker image
```
$ make docker GOOS=linux GOARCH=amd64 DOCKER_IMAGE_TAG=v0.7.1-go118
docker build --build-arg BASEIMAGE=amd64/busybox:stable --build-arg BINARY=configmap-reload-linux-amd64 -t jimmidyson/configmap-reload:v0.7.1-go118-amd64 .
Sending build context to Docker daemon  69.31MB
...
Successfully built 800f3b3854ad
Successfully tagged jimmidyson/configmap-reload:v0.7.1-go118-amd64
```

**Functional tests**

1. Downloaded prometheus helm charts to deploy on a K8s cluster
https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/templates/server/cm.yaml

2. Updated prometheus server config to point to the new configmap-reload docker image
3. Successfully deployed prometheus server with new docker image
4. Verified configmaps are updated inside the container when configmap is modified
5. Verified Go version
```
$ kubectl exec -it prometheus-server-0 -n my-namespace -- sh -c 'strings /configmap-reload | grep '^go1''
Defaulted container "my-namespace-server-configmap-reload" out of: my-namespace-server-configmap-reload, my-namespace-server
go1.18.6
```


Follow-up PR could include:

1. Update golang used by circleci builds
2. Upgrade client_golang library to v1.13.0 if needed