### PR TITLE
feat: Use distroless as base image

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Build image
       run: |
         docker buildx build \
-          --platform linux/arm64/v8,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/ppc64le,linux/s390x \
+          --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
           --build-arg GO_VERSION=$(grep -m 1 go go.mod | cut -d\  -f2) \
           -t ghcr.io/jimmidyson/configmap-reload:${{ github.event.pull_request.head.sha }} \
           .

--- a/.github/workflows/build_tag_and_main.yml
+++ b/.github/workflows/build_tag_and_main.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build and push image
       run: |
         docker buildx build \
-          --platform linux/arm64/v8,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/ppc64le,linux/s390x \
+          --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
           --build-arg GO_VERSION=$(grep -m 1 go go.mod | cut -d\  -f2) \
           -t ghcr.io/jimmidyson/configmap-reload:${{ github.ref_name == 'main' && 'dev' || github.ref_name }} \
           --push \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BASEIMAGE=busybox
+ARG BASEIMAGE=gcr.io/distroless/static-debian11:nonroot
 
 ARG GO_VERSION
 FROM --platform=${BUILDOS}/${BUILDARCH} golang:${GO_VERSION} as builder

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,6 @@ ALL_BINARIES ?= $(addprefix out/configmap-reload-, \
 									darwin-amd64 \
 									windows-amd64.exe)
 
-BASEIMAGE ?= $(DEFAULT_BASEIMAGE_$(GOARCH))
-
 BINARY=configmap-reload-linux-$(GOARCH)
 
 out/configmap-reload: out/configmap-reload-$(GOOS)-$(GOARCH)


### PR DESCRIPTION
Busybox image often has security issues in glibc, using distroless should reduce these.
