### PR TITLE
feat: Added automation to create release from tag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,26 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     schedule:
-      interval: "weekly"
+      interval: weekly
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: gomod
+    directory: /
+    groups:
+      gomod:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     schedule:
-      interval: "weekly"
+      interval: weekly

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Changes
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+    - title: Dependencies
+      labels:
+        - dependencies

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -3,23 +3,26 @@ on:
   pull_request:
     branches:
       - main
+
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
-    - name: Build image
-      run: |
-        docker buildx build \
-          --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
-          --build-arg GO_VERSION=$(grep -m 1 go go.mod | cut -d\  -f2) \
-          -t ghcr.io/jimmidyson/configmap-reload:${{ github.event.pull_request.head.sha }} \
-          .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+
+      - name: Build image
+        run: |
+          docker buildx build \
+            --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
+            --build-arg GO_VERSION=$(grep -m 1 go go.mod | cut -d\  -f2) \
+            -t ghcr.io/jimmidyson/configmap-reload:${{ github.event.pull_request.head.sha }} \
+            .

--- a/.github/workflows/build_tag_and_main.yml
+++ b/.github/workflows/build_tag_and_main.yml
@@ -5,33 +5,45 @@ on:
       - main
     tags:
       - v*
+
+permissions: read-all
+
 jobs:
   build-and-push:
     runs-on: ubuntu-22.04
     permissions:
+      contents: write
       packages: write
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
-    - name: Build and push image
-      run: |
-        docker buildx build \
-          --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
-          --build-arg GO_VERSION=$(grep -m 1 go go.mod | cut -d\  -f2) \
-          -t ghcr.io/jimmidyson/configmap-reload:${{ github.ref_name == 'main' && 'dev' || github.ref_name }} \
-          --push \
-          .
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push image
+        run: |
+          docker buildx build \
+            --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
+            --build-arg GO_VERSION=$(grep -m 1 go go.mod | cut -d\  -f2) \
+            -t ghcr.io/jimmidyson/configmap-reload:${{ github.ref_name == 'main' && 'dev' || github.ref_name }} \
+            --push \
+            .
+
+      - name: Create release
+        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          token: ${{ github.token }}
+          make_latest: true
+          generate_release_notes: true


### PR DESCRIPTION
This PR updates the automation to create a GitHub release when a tag is created, the release has [generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) from the PRs. I've also updated the GH actions for security best practices and updated Dependabot to group non-major updates as a single PR per ecosystem.

Closes #66