### PR TITLE
Allow dependabot to keep your golang version current

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,9 @@ updates:
           - patch
     schedule:
       interval: weekly
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -23,6 +23,5 @@ jobs:
         run: |
           docker buildx build \
             --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
-            --build-arg GO_VERSION=$(grep -m 1 go go.mod | cut -d\  -f2) \
             -t ghcr.io/jimmidyson/configmap-reload:${{ github.event.pull_request.head.sha }} \
             .

--- a/.github/workflows/build_tag_and_main.yml
+++ b/.github/workflows/build_tag_and_main.yml
@@ -35,7 +35,6 @@ jobs:
         run: |
           docker buildx build \
             --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
-            --build-arg GO_VERSION=$(grep -m 1 go go.mod | cut -d\  -f2) \
             -t ghcr.io/jimmidyson/configmap-reload:${{ github.ref_name == 'main' && 'dev' || github.ref_name }} \
             --push \
             .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@
 
 ARG BASEIMAGE=gcr.io/distroless/static-debian11:nonroot
 
-FROM --platform=${BUILDPLATFORM} golang:1.24.1@sha256:af0bb3052d6700e1bc70a37bca483dc8d76994fd16ae441ad72390eea6016d03 as builder
-
-ENV GOTOOLCHAIN=auto
+FROM --platform=${BUILDPLATFORM} golang:1.24.2@sha256:1ecc479bc712a6bdb56df3e346e33edcc141f469f82840bab9f4bc2bc41bf91d AS builder
 
 COPY . /src
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 
 ARG BASEIMAGE=gcr.io/distroless/static-debian11:nonroot
 
-ARG GO_VERSION
-FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} as builder
+FROM --platform=${BUILDPLATFORM} golang:1.24.1@sha256:af0bb3052d6700e1bc70a37bca483dc8d76994fd16ae441ad72390eea6016d03 as builder
 
 ENV GOTOOLCHAIN=auto
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/jimmidyson/configmap-reload
 
 go 1.21
 
-toolchain go1.23.1
+toolchain go1.24.2
 
 require (
 	github.com/fsnotify/fsnotify v1.8.0


### PR DESCRIPTION
Allow dependabot to keep your golang version current.

Today, people are having to manually modify the go.mod file and go.sum file to tell your ci/cd to using a new go image.

This Pr stops doing that,  instead it adds Docker to the dependabot config, so dependabot and keep the go compiler updated for your, automatically.

This also simplifies your build a little bit.

Thanks for your consideration  