### PR TITLE
Add SIGHUP-based reload option, per-process metrics, and mutual-exclusion validation for webhook vs target process

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -2,7 +2,7 @@ name: build-pr
 on:
   pull_request:
     branches:
-      - main
+    - main
 
 permissions: read-all
 
@@ -10,18 +10,18 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Checkout code
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Build image
-        run: |
-          docker buildx build \
-            --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
-            -t ghcr.io/jimmidyson/configmap-reload:${{ github.event.pull_request.head.sha }} \
-            .
+    - name: Build image
+      run: |
+        docker buildx build \
+          --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
+          -t ghcr.io/${{ github.repository_owner }}/configmap-reload:${{ github.event.pull_request.head.sha }} \
+          .

--- a/.github/workflows/build_tag_and_main.yml
+++ b/.github/workflows/build_tag_and_main.yml
@@ -2,9 +2,9 @@ name: build-and-push-tag-and-main
 on:
   push:
     branches:
-      - main
+    - main
     tags:
-      - v*
+    - v*
 
 permissions: read-all
 
@@ -15,34 +15,34 @@ jobs:
       contents: write
       packages: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Checkout code
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
 
-      - name: Build and push image
-        run: |
-          docker buildx build \
-            --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
-            -t ghcr.io/jimmidyson/configmap-reload:${{ github.ref_name == 'main' && 'dev' || github.ref_name }} \
-            --push \
-            .
+    - name: Build and push image
+      run: |
+        docker buildx build \
+          --platform linux/arm64/v8,linux/amd64,linux/arm,linux/ppc64le,linux/s390x \
+          -t ghcr.io/${{ github.repository_owner }}/configmap-reload:${{ github.ref_name == 'main' && 'dev' || github.ref_name }} \
+          --push \
+          .
 
-      - name: Create release
-        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2.3.3
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          token: ${{ github.token }}
-          make_latest: true
-          generate_release_notes: true
+    - name: Create release
+      uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2.3.3
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        token: ${{ github.token }}
+        make_latest: true
+        generate_release_notes: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG BASEIMAGE=gcr.io/distroless/static-debian11:nonroot
 
-FROM --platform=${BUILDPLATFORM} golang:1.25.1@sha256:8305f5fa8ea63c7b5bc85bd223ccc62941f852318ebfbd22f53bbd0b358c07e1 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.25.1@sha256:ab1f5c47de0f2693ed97c46a646bde2e4f380e40c173454d00352940a379af60 AS builder
 
 COPY . /src
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -1,36 +1,33 @@
 # Kubernetes ConfigMap Reload
 
-[![license](https://img.shields.io/github/license/jimmidyson/configmap-reload.svg?maxAge=2592000)](https://github.com/jimmidyson/configmap-reload)
-[![Docker Stars](https://img.shields.io/docker/stars/jimmidyson/configmap-reload.svg?maxAge=2592000)](https://hub.docker.com/r/jimmidyson/configmap-reload/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/jimmidyson/configmap-reload.svg?maxAge=2592000)](https://hub.docker.com/r/jimmidyson/configmap-reload/)
+[![license](https://img.shields.io/github/license/fitsegreat/configmap-reload.svg?maxAge=2592000)](https://github.com/fitsegreat/configmap-reload)
+[![Docker Stars](https://img.shields.io/docker/stars/fitsegreat/configmap-reload.svg?maxAge=2592000)](https://ghcr.io/v2/fitsegreat/configmap-reload/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/fitsegreat/configmap-reload.svg?maxAge=2592000)](https://ghcr.io/v2/fitsegreat/configmap-reload/)
 
 **configmap-reload** is a simple binary to trigger a reload when Kubernetes ConfigMaps or Secrets, mounted into pods,
 are updated.
 It watches mounted volume dirs and notifies the target process that the config map has been changed.
-It currently only supports sending an HTTP request, but in future it is expected to support sending OS
-(e.g. SIGHUP) once Kubernetes supports pod PID namespaces.
-
-Since version v0.10, the Docker image is available from ghcr.io at <https://github.com/jimmidyson/configmap-reload/pkgs/container/configmap-reload>.
-Previous versons are available from Docker Hub at <https://hub.docker.com/r/jimmidyson/configmap-reload>
 
 ### Usage
 
 ```
 Usage of ./out/configmap-reload:
-  -volume-dir value
+  --volume-dir value
         the config map volume directory to watch for updates; may be used multiple times
-  -web.listen-address string
+  --web.listen-address string
     	  address to listen on for web interface and telemetry. (default ":9533")
-  -web.telemetry-path string
+  --web.telemetry-path string
     	  path under which to expose metrics. (default "/metrics")
-  -webhook-method string
+  --webhook-method string
         the HTTP method url to use to send the webhook (default "POST")
-  -webhook-status-code int
+  --webhook-status-code int
         the HTTP status code indicating successful triggering of reload (default 200)
-  -webhook-url string
-        the url to send a request to when the specified config map volume directory has been updated
-  -webhook-retries integer
+  --webhook-url string
+        the url to send a request to when the specified config map volume directory has been updated (ignored if --target-process-name is set)
+  --webhook-retries integer
         the amount of times to retry the webhook reload request
+  --target-process-name
+        Name of the target application process to send SIGHUP to when a filesystem change is detected; may be used multiple times. If empty, a webhook will be triggered instead.
 ```
 
 ### License

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Kubernetes ConfigMap Reload
 
-[![license](https://img.shields.io/github/license/fitsegreat/configmap-reload.svg?maxAge=2592000)](https://github.com/fitsegreat/configmap-reload)
-[![Docker Stars](https://img.shields.io/docker/stars/fitsegreat/configmap-reload.svg?maxAge=2592000)](https://ghcr.io/v2/fitsegreat/configmap-reload/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/fitsegreat/configmap-reload.svg?maxAge=2592000)](https://ghcr.io/v2/fitsegreat/configmap-reload/)
+[![license](https://img.shields.io/github/license/jimmidyson/configmap-reload.svg?maxAge=2592000)](https://github.com/jimmidyson/configmap-reload)
+[![Docker Stars](https://img.shields.io/docker/stars/jimmidyson/configmap-reload.svg?maxAge=2592000)](https://hub.docker.com/r/jimmidyson/configmap-reload/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/jimmidyson/configmap-reload.svg?maxAge=2592000)](https://hub.docker.com/r/jimmidyson/configmap-reload/)
 
 **configmap-reload** is a simple binary to trigger a reload when Kubernetes ConfigMaps or Secrets, mounted into pods,
 are updated.

--- a/configmap-reload.go
+++ b/configmap-reload.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"syscall"
 	"time"
 
 	fsnotify "github.com/fsnotify/fsnotify"
@@ -21,11 +23,13 @@ const namespace = "configmap_reload"
 var (
 	volumeDirs        volumeDirsFlag
 	webhook           webhookFlag
-	webhookMethod     = flag.String("webhook-method", "POST", "the HTTP method url to use to send the webhook")
-	webhookStatusCode = flag.Int("webhook-status-code", 200, "the HTTP status code indicating successful triggering of reload")
-	webhookRetries    = flag.Int("webhook-retries", 1, "the amount of times to retry the webhook reload request")
+	webhookMethod     = flag.String("webhook-method", "POST", "the HTTP method url to use to send the webhook (only applies if --target-process-name is not set)")
+	webhookStatusCode = flag.Int("webhook-status-code", 200, "the HTTP status code indicating successful triggering of reload (only applies if --target-process-name is not set)")
+	webhookRetries    = flag.Int("webhook-retries", 1, "the amount of times to retry the webhook reload request (only applies if --target-process-name is not set)")
 	listenAddress     = flag.String("web.listen-address", ":9533", "Address to listen on for web interface and telemetry.")
 	metricPath        = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+	// targetProcessNames is now a custom flag type to accept multiple values
+	targetProcessNames processNamesFlag
 
 	lastReloadError = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
@@ -57,6 +61,23 @@ var (
 		Name:      "requests_total",
 		Help:      "Total requests by response status code",
 	}, []string{"webhook", "status_code"})
+
+	// New Prometheus metrics for SIGHUP operations
+	sighupLastReloadError = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "sighup_last_reload_error",
+		Help:      "Whether the last SIGHUP reload resulted in an error (1 for error, 0 for success)",
+	}, []string{"process_name"})
+	sighupSuccesses = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "sighup_success_reloads_total",
+		Help:      "Total success SIGHUP reload calls",
+	}, []string{"process_name"})
+	sighupErrorsByReason = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "sighup_request_errors_total",
+		Help:      "Total SIGHUP request errors by reason",
+	}, []string{"process_name", "reason"})
 )
 
 func init() {
@@ -66,11 +87,17 @@ func init() {
 	prometheus.MustRegister(requestErrorsByReason)
 	prometheus.MustRegister(watcherErrors)
 	prometheus.MustRegister(requestsByStatusCode)
+	// Register new SIGHUP metrics
+	prometheus.MustRegister(sighupLastReloadError)
+	prometheus.MustRegister(sighupSuccesses)
+	prometheus.MustRegister(sighupErrorsByReason)
 }
 
 func main() {
 	flag.Var(&volumeDirs, "volume-dir", "the config map volume directory to watch for updates; may be used multiple times")
-	flag.Var(&webhook, "webhook-url", "the url to send a request to when the specified config map volume directory has been updated")
+	flag.Var(&webhook, "webhook-url", "the url to send a request to when the specified config map volume directory has been updated (ignored if --target-process-name is set)")
+	// Register the new targetProcessNames flag
+	flag.Var(&targetProcessNames, "target-process-name", "Name of the target application process to send SIGHUP to when a filesystem change is detected; may be used multiple times. If empty, a webhook will be triggered instead.")
 	flag.Parse()
 
 	if len(volumeDirs) < 1 {
@@ -80,8 +107,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	if len(webhook) < 1 {
-		log.Println("Missing webhook-url")
+	// Validate that either webhook-url OR target-process-name is set, but not both
+	webhookSet := len(webhook) > 0
+	targetProcessNameSet := len(targetProcessNames) > 0
+
+	if !webhookSet && !targetProcessNameSet {
+		log.Println("Error: Either --webhook-url or --target-process-name must be specified.")
+		log.Println()
+		flag.Usage()
+		os.Exit(1)
+	}
+	if webhookSet && targetProcessNameSet {
+		log.Println("Error: Cannot specify both --webhook-url and --target-process-name. Choose one strategy.")
 		log.Println()
 		flag.Usage()
 		os.Exit(1)
@@ -97,57 +134,22 @@ func main() {
 		for {
 			select {
 			case event := <-watcher.Events:
+				// Handle filesystem events
 				if !isValidEvent(event) {
 					continue
 				}
-				log.Println("config map updated")
-				for _, h := range webhook {
-					begun := time.Now()
-					req, err := http.NewRequest(*webhookMethod, h.String(), nil)
-					if err != nil {
-						setFailureMetrics(h.String(), "client_request_create")
-						log.Println("error:", err)
-						continue
-					}
-					userInfo := h.User
-					if userInfo != nil {
-						if password, passwordSet := userInfo.Password(); passwordSet {
-							req.SetBasicAuth(userInfo.Username(), password)
-						}
-					}
+				log.Println("Config map updated via filesystem event.")
 
-					successfulReloadWebhook := false
-
-					for retries := *webhookRetries; retries != 0; retries-- {
-						log.Printf("performing webhook request (%d/%d)", retries, *webhookRetries)
-						resp, err := http.DefaultClient.Do(req)
-						if err != nil {
-							setFailureMetrics(h.String(), "client_request_do")
-							log.Println("error:", err)
-							time.Sleep(time.Second * 10)
-							continue
-						}
-						resp.Body.Close()
-						requestsByStatusCode.WithLabelValues(h.String(), strconv.Itoa(resp.StatusCode)).Inc()
-						if resp.StatusCode != *webhookStatusCode {
-							setFailureMetrics(h.String(), "client_response")
-							log.Println("error:", "Received response code", resp.StatusCode, ", expected", *webhookStatusCode)
-							time.Sleep(time.Second * 10)
-							continue
-						}
-
-						setSuccessMetrics(h.String(), begun)
-						log.Println("successfully triggered reload")
-						successfulReloadWebhook = true
-						break
-					}
-
-					if !successfulReloadWebhook {
-						setFailureMetrics(h.String(), "retries_exhausted")
-						log.Println("error:", "Webhook reload retries exhausted")
-					}
+				if targetProcessNameSet { // Check if any target process names are set
+					// If target-process-name(s) are set, find PIDs and send SIGHUP
+					sendSIGHUPToTargetProcesses(targetProcessNames)
+				} else {
+					// If no target-process-name is set, trigger the webhook reload
+					log.Println("Triggering webhook reload...")
+					triggerWebhookReload()
 				}
 			case err := <-watcher.Errors:
+				// Handle watcher errors
 				watcherErrors.Inc()
 				log.Println("error:", err)
 			}
@@ -165,6 +167,133 @@ func main() {
 	log.Fatal(serverMetrics(*listenAddress, *metricPath))
 }
 
+// sendSIGHUPToTargetProcesses iterates through a list of process names,
+// finds their PIDs, and sends a SIGHUP signal to each found process.
+func sendSIGHUPToTargetProcesses(processNames []string) {
+	for _, procName := range processNames {
+		pid, err := findPIDbyName(procName)
+		if err != nil {
+			log.Printf("Error finding PID for process '%s': %v", procName, err)
+			setSIGHUPFailureMetrics(procName, "find_pid_error")
+		} else if pid == 0 {
+			log.Printf("Process '%s' not found.", procName)
+			setSIGHUPFailureMetrics(procName, "process_not_found")
+		} else {
+			log.Printf("Attempting to send SIGHUP to target process '%s' with PID: %d", procName, pid)
+			proc, err := os.FindProcess(pid)
+			if err != nil {
+				log.Printf("Error finding process object for PID %d: %v", pid, err)
+				setSIGHUPFailureMetrics(procName, "find_proc_object_error")
+			} else {
+				if err := proc.Signal(syscall.SIGHUP); err != nil {
+					log.Printf("Error sending SIGHUP to target process (PID %d): %v", pid, err)
+					setSIGHUPFailureMetrics(procName, "send_sighup_error")
+				} else {
+					log.Printf("Successfully sent SIGHUP to target process '%s' with PID: %d", procName, pid)
+					setSIGHUPSuccessMetrics(procName)
+				}
+			}
+		}
+	}
+}
+
+// findPIDbyName attempts to find the PID of a process by its name.
+// It iterates through /proc/<pid>/comm to find a matching process.
+// Returns the first matching PID found, or 0 if not found, along with an error.
+func findPIDbyName(processName string) (int, error) {
+	// Read the /proc directory
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0, fmt.Errorf("failed to read /proc directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		// Check if the entry name is a PID (a number)
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue // Not a PID directory
+		}
+
+		// Read the 'comm' file for the process (command name)
+		commPath := filepath.Join("/proc", entry.Name(), "comm")
+		commBytes, err := os.ReadFile(commPath)
+		if err != nil {
+			// This can happen for processes that exit or permission issues, just skip
+			continue
+		}
+
+		// Trim whitespace (especially newline) and compare
+		commName := strings.TrimSpace(string(commBytes))
+		if commName == processName {
+			return pid, nil // Found a match
+		}
+	}
+
+	return 0, nil // Process not found
+}
+
+// triggerWebhookReload encapsulates the logic for sending webhook requests
+func triggerWebhookReload() {
+	for _, h := range webhook {
+		begun := time.Now()
+		req, err := http.NewRequest(*webhookMethod, h.String(), nil)
+		if err != nil {
+			setFailureMetrics(h.String(), "client_request_create")
+			log.Println("error creating webhook request:", err)
+			continue
+		}
+		userInfo := h.User
+		if userInfo != nil {
+			if password, passwordSet := userInfo.Password(); passwordSet {
+				req.SetBasicAuth(userInfo.Username(), password)
+			}
+		}
+
+		successfulReloadWebhook := false
+
+		for retries := *webhookRetries; retries != 0; retries-- {
+			log.Printf("Performing webhook request to %s (%d/%d)", h.String(), *webhookRetries-retries+1, *webhookRetries)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				setFailureMetrics(h.String(), "client_request_do")
+				log.Println("error performing webhook request:", err)
+				time.Sleep(time.Second * 10) // Wait before retrying
+				continue
+			}
+			resp.Body.Close()
+			requestsByStatusCode.WithLabelValues(h.String(), strconv.Itoa(resp.StatusCode)).Inc()
+			if resp.StatusCode != *webhookStatusCode {
+				setFailureMetrics(h.String(), "client_response")
+				log.Printf("error: Received response code %d from %s, expected %d", resp.StatusCode, h.String(), *webhookStatusCode)
+				time.Sleep(time.Second * 10) // Wait before retrying
+				continue
+			}
+
+			setSuccessMetrics(h.String(), begun)
+			log.Printf("Successfully triggered reload for %s", h.String())
+			successfulReloadWebhook = true
+			break // Break out of retry loop on success
+		}
+
+		if !successfulReloadWebhook {
+			setFailureMetrics(h.String(), "retries_exhausted")
+			log.Printf("error: Webhook reload retries exhausted for %s", h.String())
+		}
+	}
+}
+
+// setSIGHUPFailureMetrics updates Prometheus metrics for failed SIGHUP attempts.
+func setSIGHUPFailureMetrics(procName, reason string) {
+	sighupErrorsByReason.WithLabelValues(procName, reason).Inc()
+	sighupLastReloadError.WithLabelValues(procName).Set(1.0)
+}
+
+// setSIGHUPSuccessMetrics updates Prometheus metrics for successful SIGHUP attempts.
+func setSIGHUPSuccessMetrics(procName string) {
+	sighupSuccesses.WithLabelValues(procName).Inc()
+	sighupLastReloadError.WithLabelValues(procName).Set(0.0)
+}
+
 func setFailureMetrics(h, reason string) {
 	requestErrorsByReason.WithLabelValues(h, reason).Inc()
 	lastReloadError.WithLabelValues(h).Set(1.0)
@@ -177,6 +306,7 @@ func setSuccessMetrics(h string, begun time.Time) {
 }
 
 func isValidEvent(event fsnotify.Event) bool {
+	// Only trigger on create events for the "..data" symlink
 	if event.Op&fsnotify.Create != fsnotify.Create {
 		return false
 	}
@@ -202,9 +332,19 @@ func serverMetrics(listenAddress, metricsPath string) error {
 	return http.ListenAndServe(listenAddress, nil)
 }
 
-type volumeDirsFlag []string
+// processNamesFlag is a custom flag type to allow multiple --target-process-name flags
+type processNamesFlag []string
 
-type webhookFlag []*url.URL
+func (p *processNamesFlag) Set(value string) error {
+	*p = append(*p, value)
+	return nil
+}
+
+func (p *processNamesFlag) String() string {
+	return fmt.Sprint(*p)
+}
+
+type volumeDirsFlag []string
 
 func (v *volumeDirsFlag) Set(value string) error {
 	*v = append(*v, value)
@@ -214,6 +354,8 @@ func (v *volumeDirsFlag) Set(value string) error {
 func (v *volumeDirsFlag) String() string {
 	return fmt.Sprint(*v)
 }
+
+type webhookFlag []*url.URL
 
 func (v *webhookFlag) Set(value string) error {
 	u, err := url.Parse(value)


### PR DESCRIPTION
This PR introduces a significant new feature to `configmap-reload`, allowing it to trigger application reloads by sending a `SIGHUP` signal to a target process. This serves as an alternative to the existing webhook-based reload mechanism. #73  #23 

This change makes `configmap-reload` more versatile, as many common server applications (like Nginx, HAProxy, Prometheus, etc.) use the `SIGHUP` signal as a standard way to gracefully reload their configuration without a full restart.

**Key Changes:**
- **New `--target-process-name` Flag:**

  - A new repeatable flag, `--target-process-name`, allows users to specify one or more process names to signal.
  - When a change in a watched volume is detected, `configmap-reload` will find the process ID (PID) for each specified name and send it a `SIGHUP`.
- **Mutually Exclusive Reload Strategies:**

  - The tool now validates that either `--webhook-url` or `--target-process-name` is provided, but not both. This ensures a clear and unambiguous reload strategy.
- **PID Discovery:**

  - A new function, `findPIDbyName`, has been implemented to discover PIDs by reading the `/proc` filesystem. It iterates through `/proc/[pid]/comm` files to find processes matching the target name(s).
- **New Prometheus Metrics for SIGHUP:**

  - To ensure the new mechanism is observable, a dedicated set of Prometheus metrics has been added:
    - `configmap_reload_sighup_last_reload_error`: Indicates if the last SIGHUP attempt for a process failed.
    - `configmap_reload_sighup_success_reloads_total`: A counter for successful SIGHUP signals sent.
    - `configmap_reload_sighup_request_errors_total`: A counter for errors during the SIGHUP process, labeled by reason (e.g., `process_not_found`, `send_sighup_error`).
- **Documentation Update:**

The [README.md](README.md) has been updated to include documentation for the new `--target-process-name` flag and clarify its relationship with the webhook flags.

This enhancement allows for simpler integration in environments where applications follow the `SIGHUP` convention for reloads, removing the need for an intermediate webhook receiver.