### PR TITLE
Accept fsnotify Write for ..data so ConfigMap updates trigger reload

### DIFF
--- a/configmap-reload.go
+++ b/configmap-reload.go
@@ -177,7 +177,7 @@ func setSuccessMetrics(h string, begun time.Time) {
 }
 
 func isValidEvent(event fsnotify.Event) bool {
-	if event.Op&fsnotify.Create != fsnotify.Create {
+	if event.Op&fsnotify.Create != fsnotify.Create && event.Op&fsnotify.Write != fsnotify.Write {
 		return false
 	}
 	if filepath.Base(event.Name) != "..data" {


### PR DESCRIPTION
Symlink swap is often reported as Write, not Create. Accept both.

Fix https://github.com/jimmidyson/configmap-reload/issues/190